### PR TITLE
Fix ffmpeg command on os x

### DIFF
--- a/vimeo-download.py
+++ b/vimeo-download.py
@@ -32,7 +32,7 @@ INSTANCE_TEMP = os.path.join(TEMP_DIR, TIMESTAMP)
 OS_WIN = True if os.name == "nt" else False
 
 # Find ffmpeg executable
-FFMPEG_BIN = 'ffmpeg.exe' if OS_WIN else distutils.spawn.find_executable("ffmpeg")
+FFMPEG_BIN = 'ffmpeg.exe' if OS_WIN else 'ffmpeg'
 
 def download_video(base_url, content):
     """Downloads the video portion of teht content into the INSTANCE_TEMP folder"""


### PR DESCRIPTION
The originally code triggered the following error on OS X:

```
Traceback (most recent call last):
  File "vimeo-download.py", line 35, in <module>
    FFMPEG_BIN = 'ffmpeg.exe' if OS_WIN else distutils.spawn.find_executable("ffmpeg")
AttributeError: 'module' object has no attribute 'spawn'
```

Just changing it to `else 'ffmpeg'` seems to work on my system.