### PR TITLE
Python 3 support + No coding for video + GNU Parallel instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,23 @@ Downloads segmented audio+video from Vimeo and saves as .mp4
 This script is useful for cases where youtube-dl is unable to find the master url,
 for example on pages that require login or cookies.
 
-Install
+Installation 
 =======
-Install [ffmpeg](https://trac.ffmpeg.org/wiki/CompilationGuide).
 
 Install requirements with `pip install -r requirements.txt`
+
+### Installing ffmpeg
+
+Compilation instruction: https://trac.ffmpeg.org/wiki/CompilationGuide
+
+For ubuntu users:
+
+    sudo add-apt-repository ppa:mc3man/trusty-media && sudo apt-get update 
+    sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 8E51A6D660CD88D67D65221D90BD7EACED8E640A
+    sudo apt-get install ffmpeg
+
+(The instructions are taken from [here](http://help.ubuntu.ru/wiki/ffmpeg) - warning: Russian!)
+
 
 Usage
 =====

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ for example on pages that require login or cookies.
 
 Install
 =======
+Install [ffmpeg](https://trac.ffmpeg.org/wiki/CompilationGuide).
 
 Install requirements with `pip install -r requirements.txt`
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,15 @@ To use this script, the master url needs to be manually extracted from the page:
 To get the master url:
 
    1. Open the network tab in the inspector
-   2. Find the url of a request to the master.json file
+   2. Find the url of a request to the `master.json` file
    3. Run the script with the url as argument
+
+You can download multiple files in parallel with GPU Parallel:
+
+   `parallel -a master-files.txt python vimeo-download.py --url "{}"`
+
+Where `master-files.txt` contains a list of master URLs
+
 
 Acknowledgements
 =======

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ pyparsing==2.2.0
 requests==2.13.0
 six==1.10.0
 tqdm==4.11.2
+urllib3==1.21.1

--- a/vimeo-download.py
+++ b/vimeo-download.py
@@ -43,7 +43,7 @@ else:
 def download_video(base_url, content):
     """Downloads the video portion of teht content into the INSTANCE_TEMP folder"""
     heights = [(i, d['height']) for (i, d) in enumerate(content['video'])]
-    idx, _ = max(heights, key=lambda (_, h): h)
+    idx, _ = max(heights, key=lambda t: t[1])
     video = content['video'][idx]
     video_base_url = base_url + 'video/' + video['base_url']
     print('video base url:', video_base_url)
@@ -122,7 +122,7 @@ def merge_audio_video(input_timestamp, output_filename):
             '-i', audio_filename,
             '-i', video_filename,
             '-acodec', 'copy',
-            '-vcodec', 'h264',
+            '-vcodec', 'copy',
             output_filename ]
     print("ffmpeg command is:", command)
 
@@ -172,3 +172,4 @@ if __name__ == "__main__":
     # Combine audio and video
     if not args.skip_merge:
         merge_audio_video(TIMESTAMP, output_filename)
+

--- a/vimeo-download.py
+++ b/vimeo-download.py
@@ -12,21 +12,26 @@ import distutils
 import argparse
 import datetime
 
+import random
+import string
 
 # Prefix for this run
 TIMESTAMP = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
+SALT = ''.join(random.choice(string.digits) for _ in range(3))
+OUT_PREFIX = TIMESTAMP + '-' + SALT
 
 # Create temp and output paths based on where the executable is located
 BASE_DIR = os.path.dirname(os.path.realpath(__file__))
 TEMP_DIR = os.path.join(BASE_DIR, "temp")
 OUTPUT_DIR = os.path.join(BASE_DIR, "output")
+
 for directory in (TEMP_DIR, OUTPUT_DIR):
     if not os.path.exists(directory):
         print("Creating {}...".format(directory))
         os.makedirs(directory)
 
 # create temp directory right before we need it
-INSTANCE_TEMP = os.path.join(TEMP_DIR, TIMESTAMP)
+INSTANCE_TEMP = os.path.join(TEMP_DIR, OUT_PREFIX)
 
 # Check operating system
 OS_WIN = True if os.name == "nt" else False
@@ -115,9 +120,9 @@ def download_audio(base_url, content):
     audio_file.flush()
     audio_file.close()
 
-def merge_audio_video(input_timestamp, output_filename):
-    audio_filename = os.path.join(TEMP_DIR, TIMESTAMP, "a.mp3")
-    video_filename = os.path.join(TEMP_DIR, TIMESTAMP, "v.mp4")
+def merge_audio_video(output_filename):
+    audio_filename = os.path.join(TEMP_DIR, OUT_PREFIX, "a.mp3")
+    video_filename = os.path.join(TEMP_DIR, OUT_PREFIX, "v.mp4")
     command = [ FFMPEG_BIN,
             '-i', audio_filename,
             '-i', video_filename,
@@ -148,7 +153,7 @@ if __name__ == "__main__":
     if args.output:
         output_filename = os.path.join(OUTPUT_DIR, args.output + '.mp4')
     else:
-        output_filename = os.path.join(OUTPUT_DIR, '{}_video.mp4'.format(TIMESTAMP))
+        output_filename = os.path.join(OUTPUT_DIR, '{}_video.mp4'.format(OUT_PREFIX))
     print("Output filename set to:", output_filename)
 
     if not args.skip_download:
@@ -171,5 +176,5 @@ if __name__ == "__main__":
 
     # Combine audio and video
     if not args.skip_merge:
-        merge_audio_video(TIMESTAMP, output_filename)
+        merge_audio_video(output_filename)
 


### PR DESCRIPTION
This pull request contains 3 things:

1. The old code doesn't support python 3, it's fixed now 
2. Previously video codec was explicitly specified, so `ffmpeg` was recoding the video. It takes time and not really needed - which is why now it's set to `copy`
3. Some handy instructions for executing this script in parallel for multiple files at once