### PR TITLE
Changed import urlparse to urllib.parse as urlparse

### DIFF
--- a/vimeo-download.py
+++ b/vimeo-download.py
@@ -10,7 +10,7 @@ import subprocess as sp
 import os
 import distutils.core
 import argparse
-import urlparse
+import urllib.parse as urlparse
 import datetime
 
 import random


### PR DESCRIPTION
Hello.
`urlparse` was moved to `urllib.parse` in Python3.
Cheers.